### PR TITLE
Added a missing comma to settings JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For each item, you need to provide at least one of the filters
             "settings": {
                 "font_size" : 12
             }
-        }
+        },
         {
             // apply this setting when first line matches
             "first_line_match": ["#!/.*?/sh"],


### PR DESCRIPTION
Added a missing comma to the example settings JSON provided in the README.